### PR TITLE
Use libc from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ crate_type = [ "rlib", "dylib" ]
 default = []
 netmap_with_libs = []
 
+[dependencies]
+libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(libc)]
 #![allow(bad_style)]
 extern crate libc;
 

--- a/src/netmap_user.rs
+++ b/src/netmap_user.rs
@@ -1,3 +1,4 @@
+extern crate libc;
 use libc::{c_int, c_char, c_void};
 
 use netmap::*;


### PR DESCRIPTION
This is the recommended way to use `libc`. Also makes this compile on stable rust.
