### PR TITLE
Various fixes

### DIFF
--- a/src/netmap.rs
+++ b/src/netmap.rs
@@ -46,6 +46,7 @@ pub struct netmap_ring {
 
     pub ts: timeval,
 
+    _padding: [u8; 72],
     pub sem: [u8; 128], // FIXME  __attribute__((__aligned__(NM_CACHE_ALIGN)))
 
     pub slot: [netmap_slot; 0], // FIXME Check struct size/field alignment

--- a/src/netmap.rs
+++ b/src/netmap.rs
@@ -140,9 +140,9 @@ pub const NIOCGINFO: c_ulong = 3225184657;
 #[cfg(target_os = "linux")]
 pub const NIOCREGIF: c_ulong = 3225184658;
 #[cfg(target_os = "linux")]
-pub const NIOTXSYNC: c_uint = 27028;
+pub const NIOCTXSYNC: c_uint = 27028;
 #[cfg(target_os = "linux")]
-pub const NIORXSYNC: c_uint = 27029;
+pub const NIOCRXSYNC: c_uint = 27029;
 #[cfg(target_os = "linux")]
 pub const NIOCCONFIG: c_ulong = 3239078294;
 

--- a/src/netmap.rs
+++ b/src/netmap.rs
@@ -1,6 +1,5 @@
-use libc::{c_int, c_uint, c_ulong, c_char, timeval, ssize_t};
+use libc::{c_int, c_uint, c_ulong, c_char, timeval, ssize_t, IF_NAMESIZE};
 
-pub const IF_NAMESIZE: usize = 16;
 pub const IFNAMSIZ: usize = IF_NAMESIZE;
 
 pub const NETMAP_API: c_int = 11;

--- a/src/netmap.rs
+++ b/src/netmap.rs
@@ -78,8 +78,6 @@ pub struct netmap_if {
 
 pub const NI_PRIV_MEM: c_int = 0x1;
 
-pub const SIZEOF_NR_NAME: usize = IFNAMSIZ;
-
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct nmreq {

--- a/src/netmap_user.rs
+++ b/src/netmap_user.rs
@@ -24,13 +24,13 @@ pub unsafe fn NETMAP_IF<U>(_base: *mut U, _ofs: isize) -> *mut netmap_if {
 // FIXME It's possible the pointer arithmetic here uses the wrong integer types.
 #[inline(always)]
 pub unsafe fn NETMAP_TXRING(nifp: *mut netmap_if, index: isize) -> *mut netmap_ring {
-    let ptr = (&mut (*nifp).ring_ofs as *mut [isize; 0]) as *mut c_void;
+    let ptr = (&mut (*nifp).ring_ofs as *mut [isize; 0]) as *mut isize;
     _NETMAP_OFFSET(nifp, *(ptr.offset(index) as *mut isize))
 }
 
 #[inline(always)]
 pub unsafe fn NETMAP_RXRING(nifp: *mut netmap_if, index: isize) -> *mut netmap_ring {
-    let ptr = (&mut (*nifp).ring_ofs as *mut [isize; 0]) as *mut c_void;
+    let ptr = (&mut (*nifp).ring_ofs as *mut [isize; 0]) as *mut isize;
     _NETMAP_OFFSET(nifp, *(ptr.offset(index + (*nifp).ni_tx_rings as isize + 1) as *mut isize))
 }
 


### PR DESCRIPTION
These were mostly uncovered by ctest.
The biggest problem is in netmap_ring, i.e. functions operating on slots don't work without it.
`ctest` still reports alignment problems, but it looks like this is impossible to solve in today's rust (https://github.com/rust-lang/rfcs/pull/1358).
