### PR TITLE
Migrate from gcc to cc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ netmap_with_libs = []
 libc = "0.2"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0.35"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 // netmap doesn't provide these functions as a library, so we cheat, to save porting them manually
 // to Rust. This is a very ugly hack.
-extern crate gcc;
+extern crate cc;
 use std::env;
 use std::io::prelude::*;
 use std::fs;
@@ -18,7 +18,7 @@ fn main() {
                         typedef unsigned long u_long;
                         typedef unsigned char u_char;
                         #include <net/netmap_user.h>\n").unwrap();
-        gcc::Config::new()
+        cc::Build::new()
             .file(&tmp_path)
             .define("NETMAP_WITH_LIBS", None)
             .define("static", Some(""))


### PR DESCRIPTION
The package https://crates.io/crates/gcc has been deprecated. The package documentation says that the new package is https://crates.io/crates/cc. 

Signed-off-by: Sayan Chowdhury <sayan.chowdhury2012@gmail.com>