### PR TITLE
Fix NETMAP_API, NETMAP_MIN_API (netmap.rs)

### DIFF
--- a/src/netmap.rs
+++ b/src/netmap.rs
@@ -2,8 +2,8 @@ use libc::{c_int, c_uint, c_ulong, c_char, timeval, ssize_t, IF_NAMESIZE};
 
 pub const IFNAMSIZ: usize = IF_NAMESIZE;
 
-pub const NETMAP_API: c_int = 11;
-pub const NETMAP_MIN_API: c_int = 11;
+pub const NETMAP_API: c_int = 14;
+pub const NETMAP_MIN_API: c_int = 14;
 pub const NETMAP_MAX_API: c_int = 15;
 
 pub const NM_CACHE_ALIGN: c_int = 128;


### PR DESCRIPTION
The current API versions of NETMAP are defined as the following:
```

#define	NETMAP_API	14		/* current API version */

#define	NETMAP_MIN_API	14		/* min and max versions accepted */
#define	NETMAP_MAX_API	15
```