### PR TITLE
make nm_desc struct definition compatible with netmap >= v11.4

### DIFF
--- a/src/netmap.rs
+++ b/src/netmap.rs
@@ -72,7 +72,9 @@ pub struct netmap_if {
     pub ni_rx_rings: u32,
 
     pub ni_bufs_head: u32,
-    pub ni_spare1: [u32; 5],
+    pub	ni_host_tx_rings: u32, /* number of SW tx rings */
+    pub	ni_host_rx_rings: u32, /* number of SW tx rings */
+    pub ni_spare1: [u32; 3],
 
     pub ring_ofs: [ssize_t; 0], // FIXME Check this is right, see above
 }
@@ -85,7 +87,7 @@ pub struct nmreq {
     pub nr_name: [c_char; IFNAMSIZ],
     pub nr_version: u32,
     pub nr_offset: u32,
-    pub nr_memsize: size_t,
+    pub nr_memsize: u32,
     pub nr_tx_slots: u32,
     pub nr_rx_slots: u32,
     pub nr_tx_rings: u16,

--- a/src/netmap_user.rs
+++ b/src/netmap_user.rs
@@ -8,7 +8,7 @@ use netmap_util::{unlikely};
 pub use netmap_with_libs::{nm_pkthdr, nm_stat, nm_desc, P2NMD, IS_NETMAP_DESC, NETMAP_FD,
                            nm_pkt_copy, nm_cb_t, NM_OPEN_NO_MMAP, NM_OPEN_IFNAME, NM_OPEN_ARG1,
                            NM_OPEN_ARG2, NM_OPEN_ARG3, NM_OPEN_RING_CFG, nm_open, nm_close,
-                           nm_inject, nm_dispatch, nm_nextpkt};
+                           nm_inject, nm_dispatch, nm_nextpkt, nm_mmap};
 
 
 #[inline(always)]
@@ -31,7 +31,10 @@ pub unsafe fn NETMAP_TXRING(nifp: *mut netmap_if, index: isize) -> *mut netmap_r
 #[inline(always)]
 pub unsafe fn NETMAP_RXRING(nifp: *mut netmap_if, index: isize) -> *mut netmap_ring {
     let ptr = (&mut (*nifp).ring_ofs as *mut [isize; 0]) as *mut isize;
-    _NETMAP_OFFSET(nifp, *(ptr.offset(index + (*nifp).ni_tx_rings as isize + 1) as *mut isize))
+    let rr = &mut (*nifp).ni_tx_rings;
+    let r = *rr as isize;
+    let a = index + r + 1;
+    _NETMAP_OFFSET(nifp, *(ptr.offset(a) as *mut isize))
 }
 
 #[inline(always)]

--- a/src/netmap_with_libs.rs
+++ b/src/netmap_with_libs.rs
@@ -30,7 +30,7 @@ pub struct nm_desc {
     pub self_: *mut nm_desc,
     pub fd: c_int,
     pub mem: *mut c_void,
-    pub memsize: u32,
+    pub memsize: u64,
     pub done_mmap: c_int,
     pub nifp: *mut netmap_if,
     pub first_tx_ring: u16,
@@ -118,6 +118,7 @@ extern {
     pub fn nm_inject(d: *mut nm_desc, buf: *const c_void, size: size_t) -> c_int;
     pub fn nm_dispatch(d: *mut nm_desc, cnt: c_int, cb: nm_cb_t, arg: *mut c_uchar) -> c_int;
     pub fn nm_nextpkt(d: *mut nm_desc, hdr: *mut nm_pkthdr) -> *mut c_uchar;
+    pub fn nm_mmap(d: *mut nm_desc, p: *const nm_desc) -> c_int;
 }
 
 #[test]


### PR DESCRIPTION
Dear Maintainers

Please accept this PR that addresses #25 such that these bindings will work for netmap v11.4 

Currently the PR only fixes the bindings, but does not touch `cargo.toml` which would be necessary in order to prevent existing user getting bindings for a version of netmap they may not use.